### PR TITLE
Build-depend on libsdl2-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Section: games
 Priority: extra
 Build-Depends: debhelper (>= 9),
                libtcod-dev,
-               libncurses5-dev
+               libncurses5-dev,
+               libsdl2-dev
 Standards-Version: 3.9.8
 Homepage: https://sites.google.com/site/broguegame/
 


### PR DESCRIPTION
This makes the build succeed under a clean chroot such as when using `cowbuilder`.
